### PR TITLE
add XRT backend named "TEST"

### DIFF
--- a/oneflow/core/job/job_conf.proto
+++ b/oneflow/core/job/job_conf.proto
@@ -47,6 +47,7 @@ message XrtConfig {
   optional bool use_tensorrt = 2 [default = false];
   optional XlaConfig xla_config = 3;
   optional TensorRTConfig tensorrt_config = 4;
+  optional bool use_test = 5 [default = false];
 }
 
 message IndexedSlicesOptimizerConf {

--- a/oneflow/python/framework/function_util.py
+++ b/oneflow/python/framework/function_util.py
@@ -787,7 +787,10 @@ def set_use_tensorrt(func_desc, value=True):
     """
     func_desc.job_config_proto.xrt_config.use_tensorrt = value
 
-
+@oneflow_function_config('use_test')
+def set_use_test(func_desc, value = True):
+    func_desc.job_config_proto.xrt_config.use_test = value
+    
 @oneflow_function_config("tensorrt.use_fp16")
 def set_tensorrt_use_fp16(func_desc, value=True):
     r"""Whether use tensorrt fp16  or not

--- a/oneflow/xrt/api.cpp
+++ b/oneflow/xrt/api.cpp
@@ -41,6 +41,7 @@ DEFINE_bool(strict_clustering, EnvToBool(FLAGS_strict_clustering, true),
 //               "valid, Default means using no engine.");
 DEFINE_bool(use_xla_jit, EnvToBool(FLAGS_use_xla_jit, false), "It's optional to use xla jit.");
 DEFINE_bool(use_tensorrt, EnvToBool(FLAGS_use_tensorrt, false), "It's optional to use tensorrt.");
+DEFINE_bool(use_test, EnvToBool(FLAGS_use_test, false), "It's optional to use test.");
 
 DEFINE_bool(tensorrt_fp16, EnvToBool(FLAGS_tensorrt_fp16, false),
             "Enable fp16 precision for TENSORRT engine.");
@@ -154,6 +155,8 @@ XrtEngine StringToXrtEngine(const std::string &engine) {
     return xrt::XrtEngine::XLA;
   } else if (engine == "TENSORRT") {
     return xrt::XrtEngine::TENSORRT;
+  } else if (engine == "TEST") {
+    return xrt::XrtEngine::TEST;
   } else {
     LOG(FATAL) << "Unknown engine: " << engine;
   }
@@ -187,6 +190,7 @@ std::shared_ptr<XrtGraph> BuildXrtGraph(const XrtLaunchOpConf::Function &functio
 void InitXrtConfigurations(const XrtConfig &config) {
   if (config.has_use_xla_jit()) { FLAGS_use_xla_jit = config.use_xla_jit(); }
   if (config.has_use_tensorrt()) { FLAGS_use_tensorrt = config.use_tensorrt(); }
+  if (config.has_use_test()) { FLAGS_use_test = config.use_test(); }
   // Set xla configurations.
   if (config.has_tensorrt_config()) {
     const XrtConfig::TensorRTConfig &trt_config = config.tensorrt_config();
@@ -200,7 +204,7 @@ void InitXrtConfigurations(const XrtConfig &config) {
   }
 }
 
-bool XrtCompilationEnabled() { return FLAGS_use_xla_jit || FLAGS_use_tensorrt; }
+bool XrtCompilationEnabled() { return FLAGS_use_xla_jit || FLAGS_use_tensorrt || FLAGS_use_test; }
 
 XrtPassOptions CreateDefaultXrtPassOptions(bool train_phase) {
   ClusteringOptions options;
@@ -213,6 +217,7 @@ XrtPassOptions CreateDefaultXrtPassOptions(bool train_phase) {
   options.engine = (1U << XrtEngineOptionBit::kUseDefault);
   if (FLAGS_use_xla_jit) { options.engine |= (1U << XrtEngineOptionBit::kUseXlaJit); }
   if (FLAGS_use_tensorrt) { options.engine |= (1U << XrtEngineOptionBit::kUseTensorRT); }
+  if (FLAGS_use_test) { options.engine |= (1U << XrtEngineOptionBit::kUseTest); }
 
   XrtPassOptions xrt_options;
   xrt_options.clustering_options = options;

--- a/oneflow/xrt/passes/mark_cluster_id_pass.cpp
+++ b/oneflow/xrt/passes/mark_cluster_id_pass.cpp
@@ -204,6 +204,8 @@ void MarkClusterIdPass::Run(XrtGraph *graph, const XrtPassOptions &options) {
     ClusteringSubgraphs(clustering_options, XrtEngine::XLA);
   }
 
+  ClusteringSubgraphs(clustering_options, XrtEngine::TEST);
+
   RemoveInvalidClusterNodes(clustering_options);
   RerankClusterIds();
 

--- a/oneflow/xrt/passes/pass.h
+++ b/oneflow/xrt/passes/pass.h
@@ -29,6 +29,7 @@ enum XrtEngineOptionBit : int {
   kUseDefault = 0,
   kUseXlaJit = 1,
   kUseTensorRT = 2,
+  kUseTest = 3,
 };
 
 struct ClusteringOptions {

--- a/oneflow/xrt/passes/rebuild_job_pass.cpp
+++ b/oneflow/xrt/passes/rebuild_job_pass.cpp
@@ -235,6 +235,7 @@ void FoldSubgraphBuilder::BuildXrtLaunchOps() {
       switch (engine) {
         case XrtEngine::XLA: return "XLA";
         case XrtEngine::TENSORRT: return "TENSORRT";
+        case XrtEngine::TEST: return "TEST";
         default: LOG(FATAL) << "Not supported engine " << engine; return "";
       }
     }());

--- a/oneflow/xrt/test/test_executable.cpp
+++ b/oneflow/xrt/test/test_executable.cpp
@@ -1,0 +1,57 @@
+#include "oneflow/xrt/test/test_executable.h"
+
+namespace oneflow {
+namespace xrt {
+
+TestExecutable::TestExecutable(const std::string &name, const int num_inputs,
+                               const std::vector<Parameter> &outputs,
+                               const std::vector<Parameter> &temp_buffers,
+                               const std::vector<FuncCode> &func_codes,
+                               const std::vector<FuncArgumentIndices> &func_args)
+    : Executable(name, XrtEngine::TEST),
+      num_inputs_(num_inputs),
+      outputs_(outputs),
+      temp_buffers_(temp_buffers),
+      func_codes_(func_codes),
+      func_args_(func_args) {}
+
+bool TestExecutable::Run(const std::vector<Parameter> &inputs,
+                         const ExecutableRunOptions &run_options,
+                         bool block_until_done) {
+  auto PullArgs = [&](const std::vector<int> &indices) {
+    std::vector<Parameter> args;
+    for (int idx : indices) {
+      if (idx < num_inputs_) {
+        args.push_back(inputs[idx]);
+      } else if (idx < num_inputs_ + outputs_.size()) {
+        args.push_back(outputs_[idx - num_inputs_]);
+      } else {
+        idx -= (num_inputs_ + outputs_.size());
+        CHECK_GE(idx, 0);
+        CHECK_LT(idx, temp_buffers_.size());
+        args.push_back(temp_buffers_[idx]);
+      }
+    }
+    return std::move(args);
+  };
+
+  CHECK_EQ(inputs.size(), num_inputs_);
+
+  for (int i = 0; i < func_codes_.size(); ++i) {
+    auto in_args = PullArgs(func_args_[i].inputs);
+    auto out_args = PullArgs(func_args_[i].outputs);
+    func_codes_[i](in_args, out_args);
+  }
+
+  // Synchronize stream if block_until_done.
+  if (block_until_done) {
+    // TODO(hjchen2)
+  }
+
+  // All return params are the results of the executable.
+  this->results_ = run_options.return_params;
+  return true /*running status*/;
+}
+
+}  // namespace xrt
+}  // namespace oneflow

--- a/oneflow/xrt/test/test_executable.h
+++ b/oneflow/xrt/test/test_executable.h
@@ -1,0 +1,43 @@
+#ifndef ONEFLOW_XRT_TEST_TEST_EXECUTABLE_H_
+
+#include "oneflow/xrt/executable.h"
+#include "oneflow/xrt/parameter.h"
+
+#include <vector>
+#include <functional>
+
+namespace oneflow {
+namespace xrt {
+
+typedef std::function<void(const std::vector<Parameter> &,
+                           const std::vector<Parameter> &)> FuncCode;
+
+struct FuncArgumentIndices {
+  std::vector<int> inputs;
+  std::vector<int> outputs;
+};
+
+class TestExecutable : public Executable {
+ public:
+  TestExecutable(const std::string &name, const int num_inputs,
+                 const std::vector<Parameter> &outputs,
+                 const std::vector<Parameter> &temp_buffers,
+                 const std::vector<FuncCode> &func_codes,
+                 const std::vector<FuncArgumentIndices> &func_args);
+
+  bool Run(const std::vector<Parameter> &inputs,
+           const ExecutableRunOptions &run_options,
+           bool block_until_done = true) override;
+
+ private:
+  int num_inputs_;
+  std::vector<Parameter> outputs_;
+  std::vector<Parameter> temp_buffers_;
+  std::vector<FuncCode> func_codes_;
+  std::vector<FuncArgumentIndices> func_args_;
+};
+
+}  // namespace xrt
+}  // namespace oneflow
+
+#endif  // ONEFLOW_XRT_TEST_TEST_EXECUTABLE_H_

--- a/oneflow/xrt/test/test_graph_compiler.cpp
+++ b/oneflow/xrt/test/test_graph_compiler.cpp
@@ -1,0 +1,66 @@
+#include "oneflow/xrt/test/test_graph_compiler.h"
+#include "oneflow/xrt/test/test_executable.h"
+#include "oneflow/xrt/test/test_op_kernel.h"
+
+namespace oneflow {
+namespace xrt {
+
+// Register a new graph compiler for TEST engine.
+REGISTER_GRAPH_COMPILER(XrtEngine::TEST, TestGraphCompiler);
+
+std::shared_ptr<Executable> TestGraphCompiler::Compile(
+    const XrtGraph *graph,
+    const std::vector<Parameter> &entry_params,
+    const std::vector<Parameter> &return_params,
+    const std::vector<InputOutputAlias> &aliases) {
+  std::vector<Parameter> temp_buffers;
+  std::vector<FuncCode> func_codes;
+  std::vector<FuncArgumentIndices> func_args;
+
+  std::unordered_map<std::string, int> indices;
+  std::unordered_map<std::string, Parameter> all_params;
+  for (auto param : entry_params) {
+    indices.emplace(param.name(), indices.size());
+    all_params[param.name()] = param;
+  }
+  for (auto param : return_params) {
+    indices.emplace(param.name(), indices.size());
+    all_params[param.name()] = param;
+  }
+
+  algorithm::TopologyVisit(*graph, [&](const XrtNode *node) {
+    if (node->type() == "Argument") {
+      // Argument node is not computation node, so skip it.
+      return;
+    }
+
+    TestOpContext op_context(node, all_params);
+    auto op_kernel = BuildTestOpKernel(node->type());
+    op_kernel->Compile(&op_context);
+
+    func_codes.push_back(op_context.func_code_);
+
+    const auto &buffers = op_context.tmp_buffers_;
+    for (auto it = buffers.begin(); it != buffers.end(); ++it) {
+      all_params[it->first] = it->second;
+      temp_buffers.push_back(it->second);
+      indices.emplace(it->first, indices.size());
+    }
+
+    // Finalize argument indices for each function.
+    FuncArgumentIndices arg_indices;
+    for (const auto &arg : op_context.input_args_) {
+      arg_indices.inputs.push_back(indices.at(arg));
+    }
+    for (const auto &arg : op_context.output_args_) {
+      arg_indices.outputs.push_back(indices.at(arg));
+    }
+    func_args.push_back(std::move(arg_indices));
+  });
+
+  return std::make_shared<TestExecutable>(this->name_, entry_params.size(),
+                                          return_params, temp_buffers,
+                                          func_codes, func_args);
+}
+}  // namespace xrt
+}  // namespace oneflow

--- a/oneflow/xrt/test/test_graph_compiler.h
+++ b/oneflow/xrt/test/test_graph_compiler.h
@@ -1,0 +1,26 @@
+#ifndef ONEFLOW_XRT_TEST_TEST_GRAPH_COMPILER_H_
+#define ONEFLOW_XRT_TEST_TEST_GRAPH_COMPILER_H_
+
+#include "oneflow/xrt/graph_compiler.h"
+
+namespace oneflow {
+namespace xrt {
+
+class TestGraphCompiler : public GraphCompiler::Impl {
+ public:
+  explicit TestGraphCompiler(const std::string &name)
+      : GraphCompiler::Impl(name) {}
+
+  virtual ~TestGraphCompiler() = default;
+
+  std::shared_ptr<Executable> Compile(
+      const XrtGraph *graph,
+      const std::vector<Parameter> &entry_params,
+      const std::vector<Parameter> &return_params,
+      const std::vector<InputOutputAlias> &aliases) override;
+};
+
+}  // namespace xrt
+}  // namespace oneflow
+
+#endif  // ONEFLOW_XRT_TEST_TEST_GRAPH_COMPILER_H_

--- a/oneflow/xrt/test/test_op_kernel.h
+++ b/oneflow/xrt/test/test_op_kernel.h
@@ -1,0 +1,57 @@
+#ifndef ONEFLOW_XRT_TEST_TEST_OP_KERNEL_H_
+#define ONEFLOW_XRT_TEST_TEST_OP_KERNEL_H_
+
+#include "oneflow/xrt/parameter.h"
+#include "oneflow/xrt/graph/node.h"
+
+#include "oneflow/xrt/kernel/op_kernel.h"
+
+#include <functional>
+#include <unordered_map>
+#include <vector>
+
+namespace oneflow {
+namespace xrt {
+
+class TestOpContext {
+ public:
+  TestOpContext(const XrtNode *node,
+                const std::unordered_map<std::string, Parameter> &all_params)
+      : node_(node), all_params_(all_params) {}
+
+ public:
+  const XrtNode *node_;
+  const std::unordered_map<std::string, Parameter> &all_params_;
+
+  std::function<void(const std::vector<Parameter> &,
+                     const std::vector<Parameter> &)> func_code_;
+  std::vector<std::string> input_args_;
+  std::vector<std::string> output_args_;
+  std::unordered_map<std::string, Parameter> tmp_buffers_;
+};
+
+class TestOpKernel : public OpKernel<TestOpContext> {
+ public:
+  virtual void Compile(TestOpContext *ctx) = 0;
+};
+
+#define REGISTER_TEST_OP_KERNEL(OpName, KernelType)                 \
+  static auto _test_op_kernel_##OpName##_ __attribute__((unused)) = \
+      OpKernelRegistrar<TestOpContext>(#OpName)                     \
+          .SetField(XrtEngine::TEST)                                \
+          .SetDevice({XrtDevice::GPU_CUDA})                         \
+          .SetFactory([]() -> OpKernel<TestOpContext> * {           \
+                          return new KernelType;                    \
+                      })
+
+inline std::shared_ptr<OpKernel<TestOpContext>> BuildTestOpKernel(
+    const std::string &op_type) {
+  auto field = MakeXrtField(XrtDevice::GPU_CUDA, XrtEngine::TEST);
+  return std::shared_ptr<OpKernel<TestOpContext>>(
+      OpKernelBuilder<TestOpContext>()(field, op_type));
+}
+
+}  // namespace xrt
+}  // namespace oneflow
+
+#endif  // ONEFLOW_XRT_TEST_TEST_OP_KERNEL_H_

--- a/oneflow/xrt/test/test_relu_op.cpp
+++ b/oneflow/xrt/test/test_relu_op.cpp
@@ -1,0 +1,54 @@
+#include "oneflow/xrt/test/test_op_kernel.h"
+#include "oneflow/xrt/parameter.h"
+
+namespace oneflow {
+namespace xrt {
+
+// Computing relu implemented in test_relu_op.cu.
+// TODO(hjchen2): Support compute stream.
+extern void ComputeRelu(/*void *stream, */const Parameter &input,
+                        const Parameter &output);
+
+Parameter CreateParameter(const std::string &name, const Shape &shape,
+                          const DataType &data_type) {
+  // TODO(hjchen2)
+  Parameter param;
+  return param;
+}
+
+class TestReluOpKernel : public TestOpKernel {
+ public:
+  void Compile(TestOpContext *ctx) override {
+    ctx->func_code_ = [](const std::vector<Parameter> &inputs,
+                         const std::vector<Parameter> &outputs) {
+      CHECK_EQ(inputs.size(), 1);
+      CHECK_EQ(outputs.size(), 1);
+      ComputeRelu(inputs[0], outputs[0]);
+    };
+
+    for (const XrtEdge *edge : ctx->node_->in_edges()) {
+      const auto &name = edge->argument().name();
+      CHECK_GT(ctx->all_params_.count(name), 0);
+      // TODO(hjchen2): Filter duplicate input.
+      ctx->input_args_.push_back(name);
+    }
+
+    for (const XrtEdge *edge : ctx->node_->out_edges()) {
+      const auto &name = edge->argument().name();
+      // TODO(hjchen2): Filter duplicate output.
+      ctx->output_args_.push_back(name);
+      if (ctx->all_params_.count(name) == 0 &&
+          ctx->tmp_buffers_.count(name) == 0) {
+        auto param = CreateParameter(name /*argument name*/,
+                                     edge->argument().shape(),
+                                     edge->argument().data_type());
+        ctx->tmp_buffers_[name] = std::move(param);
+      }
+    }
+  }
+};
+
+REGISTER_TEST_OP_KERNEL(Relu, TestReluOpKernel).EnableTrainPhase().Finalize();
+
+}  // namespace xrt
+}  // namespace oneflow

--- a/oneflow/xrt/test/test_relu_op.cu
+++ b/oneflow/xrt/test/test_relu_op.cu
@@ -1,0 +1,31 @@
+#include "oneflow/xrt/parameter.h"
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+namespace oneflow {
+namespace xrt {
+
+__global__ void ReluKernel(const float *in, float *out, const size_t len) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  for (size_t i = tid; i < len; i += blockDim.x * gridDim.x) {
+    out[i] = (in[i] > 0.f) ? in[i] : 0.f;
+  }
+}
+
+void ComputeRelu(/*void *stream, */const Parameter &input,
+                 const Parameter &output) {
+  int64_t length = input.shape().elem_cnt();
+  CHECK_EQ(length, output.shape().elem_cnt());
+
+  const float *in = input.data<float>();
+  float *out = output.data<float>();
+
+  int num_threads = 512;
+  int num_blocks = (length + num_threads - 1) / num_threads;
+  ReluKernel<<<num_blocks, num_threads>>>(in, out, length);
+  CHECK_EQ(cudaSuccess, cudaPeekAtLastError());
+}
+
+}  // namespace xrt
+}  // namespace oneflow

--- a/oneflow/xrt/types.proto
+++ b/oneflow/xrt/types.proto
@@ -15,6 +15,7 @@ enum XrtEngine {
   XLA = 2;
   TENSORRT = 3;
   TVM = 4;
+  TEST = 5; // New backed "TEST"
 }
 
 message XrtField {


### PR DESCRIPTION
python api and global flag:
	modified:   oneflow/python/framework/function_util.py
	modified:   oneflow/core/job/job_conf.proto
	modified:   oneflow/xrt/types.proto
	modified:   oneflow/xrt/api.cpp

pass:
	modified:   oneflow/xrt/passes/mark_cluster_id_pass.cpp
	modified:   oneflow/xrt/passes/pass.h
	modified:   oneflow/xrt/passes/rebuild_job_pass.cpp

executable and compiler:
	new file:   oneflow/xrt/test/test_executable.cpp
	new file:   oneflow/xrt/test/test_executable.h
	new file:   oneflow/xrt/test/test_graph_compiler.cpp
	new file:   oneflow/xrt/test/test_graph_compiler.h
	new file:   oneflow/xrt/test/test_op_kernel.h

example op(relu):
	new file:   oneflow/xrt/test/test_relu_op.cpp
	new file:   oneflow/xrt/test/test_relu_op.cu